### PR TITLE
Weeknumber tag is shown as year

### DIFF
--- a/src/strava/utils.ts
+++ b/src/strava/utils.ts
@@ -32,7 +32,7 @@ export function toStravaActivity(user: UserData, data: any): StravaActivity {
         hideHome: data.hide_from_home ? true : false,
         trainer: data.trainer ? true : false,
         dateStart: startDate.toDate(),
-        weekOfYear: startDate.weekYear(),
+        weekOfYear: startDate.week(),
         utcStartOffset: data.utc_offset,
         totalTime: data.elapsed_time,
         movingTime: data.moving_time || data.elapsed_time,


### PR DESCRIPTION
### Issue
Weeknumber returns year instead of weeknumber.

The issue can be seen in my activity log, where I use the _weekOfYear_ tag. 
![image](https://user-images.githubusercontent.com/6660378/211769849-41d19af2-f0d1-4b7a-b41d-692ecc15b3d3.png)

## Expected behaviour

The tag is Pfitz 18/55 W${weekOfYear}R, and should return Pfitz 18/55 W2R instead if Pfitz 18/55 W2023R. 

## Solution 
Apparently dayjs function weekOfYear returns the year instead of the week. Use the function week() instead