### PR TITLE
Harden shared recipes, FIT downloads, and token logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
                 "jszip": "^3.10.1",
                 "lodash": "^4.18.1",
                 "nodemailer": "^9.1.0",
-                "paypal-rest-sdk": "^1.8.1",
                 "setmeup": "^1.9.5",
                 "typescript": "^7.0.2"
             },
@@ -1176,15 +1175,6 @@
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/buffer-crc32": {
-            "version": "0.2.13",
-            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-            "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-            "license": "MIT",
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/buffer-equal-constant-time": {
@@ -3306,29 +3296,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
-            }
-        },
-        "node_modules/paypal-rest-sdk": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/paypal-rest-sdk/-/paypal-rest-sdk-1.8.1.tgz",
-            "integrity": "sha512-Trj2GuPn10GqpICAxQh5wjxuDT7rq7DMOkvyatz05wI5xPGmqXN7UC0WfDSF9WSBs4YdcWZP0g+nY+sOdaFggw==",
-            "deprecated": "Package no longer supported. The author suggests using the @paypal/paypal-server-sdk package instead: https://www.npmjs.com/package/@paypal/paypal-server-sdk. Contact Support at https://www.npmjs.com/support for more info.",
-            "license": "SEE LICENSE IN https://github.com/paypal/PayPal-node-SDK/blob/master/LICENSE",
-            "dependencies": {
-                "buffer-crc32": "^0.2.3",
-                "semver": "^5.0.3"
-            },
-            "engines": {
-                "node": ">= v0.6.0"
-            }
-        },
-        "node_modules/paypal-rest-sdk/node_modules/semver": {
-            "version": "5.7.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver"
             }
         },
         "node_modules/picocolors": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
         "jszip": "^3.10.1",
         "lodash": "^4.18.1",
         "nodemailer": "^9.1.0",
-        "paypal-rest-sdk": "^1.8.1",
         "setmeup": "^1.9.5",
         "typescript": "^7.0.2"
     },

--- a/src/eventmanager.ts
+++ b/src/eventmanager.ts
@@ -32,7 +32,7 @@ export class EventManager extends events.EventEmitter {
             if (arg === null) continue
             if (typeof arg === "string") {
                 if (isTokenEvent && !arg.includes(" ") && ((arg.length > 36 && arg.length < 44) || (arg.split("\\.").length == 3 && arg.length > 32))) {
-                    details.push(`${arg.substring(0, 2)}*${arg.substring(-2)}`)
+                    details.push(`*${arg.slice(-2)}`)
                 } else {
                     details.push(arg)
                 }

--- a/src/garmin/activities.ts
+++ b/src/garmin/activities.ts
@@ -139,6 +139,12 @@ export class GarminActivities {
                 throw new Error("Missing activity callbackURL")
             }
 
+            // Only download FIT files from Garmin domains.
+            const callbackHost = new URL(ping.callbackURL).hostname.toLowerCase()
+            if (callbackHost != "garmin.com" && !callbackHost.endsWith(".garmin.com")) {
+                throw new Error("Invalid activity callbackURL")
+            }
+
             // Try fetching the FIT file specified in the callback URL.
             const tokens = await api.validateTokens(user)
             const res = await api.makeRequest(tokens, ping.callbackURL, "GET", true)

--- a/src/gdpr/index.ts
+++ b/src/gdpr/index.ts
@@ -104,6 +104,9 @@ export class GDPR {
             // Remove sensitive data.
             delete jsonData.User.stravaTokens
             delete jsonData.User.urlToken
+            delete jsonData.User.garminAuthState
+            delete jsonData.User.wahooAuthState
+            delete jsonData.User.spotifyAuthState
             if (jsonData.User.garmin) {
                 delete jsonData.User.garmin.tokens
             }

--- a/src/recipes/actions.ts
+++ b/src/recipes/actions.ts
@@ -1112,10 +1112,13 @@ export const toggleGearComponents = async (user: UserData, activity: StravaActiv
                 const arrGear: string[] = action.value.split(":")
                 const gearId = arrGear.shift().trim()
 
-                // Make sure the specified gear is still valid.
+                // Make sure the specified gear is still valid and belongs to the user.
                 const gear: GearWearConfig = updatedGear[gearId]?.config || (await gearwear.getById(gearId))
                 if (!gear) {
                     throw new Error(`Gear ${gearId} not found`)
+                }
+                if (gear.userId != user.id) {
+                    throw new Error(`Gear ${gearId} does not belong to user ${user.id}`)
                 }
 
                 // Make sure the component exists.

--- a/src/recipes/index.ts
+++ b/src/recipes/index.ts
@@ -579,6 +579,17 @@ export class Recipes {
             const now = new Date()
             const isNew = !recipe.id || recipe.id.substring(0, 1) != "s"
 
+            // Updating an existing shared recipe? Make sure it belongs to the owner.
+            if (!isNew) {
+                const existing: SharedRecipe = await database.get("shared-recipes", recipe.id)
+                if (!existing) {
+                    throw new Error(`Recipe ${recipe.id} not found`)
+                }
+                if (existing.userId != owner.id) {
+                    throw new Error(`Recipe ${recipe.id} does not belong to user ${owner.id}`)
+                }
+            }
+
             // Create the shared recipe.
             const sharedRecipe: SharedRecipe = {
                 id: isNew ? generateId(true) : recipe.id,
@@ -627,36 +638,6 @@ export class Recipes {
             logger.info("Recipes.deleteSharedRecipe", logHelper.user(owner), id)
         } catch (ex) {
             logger.error("Recipes.deleteSharedRecipe", logHelper.user(owner), id, ex)
-            throw ex
-        }
-    }
-
-    /**
-     * Copy a shared recipe to the user's account.
-     * @param user User requesting the shared recipe.
-     * @param sharedRecipe The shared recipe data.
-     */
-    copySharedRecipe = async (user: UserData, sharedRecipe: SharedRecipe): Promise<RecipeData> => {
-        try {
-            const recipe: RecipeData = {
-                id: generateId(),
-                sharedRecipeId: sharedRecipe.id,
-                title: sharedRecipe.title,
-                conditions: sharedRecipe.conditions,
-                actions: sharedRecipe.actions
-            }
-
-            if (sharedRecipe.defaultFor) recipe.defaultFor = sharedRecipe.defaultFor
-            if (sharedRecipe.op) recipe.op = sharedRecipe.op
-            if (sharedRecipe.samePropertyOp) recipe.samePropertyOp = sharedRecipe.samePropertyOp
-
-            await database.merge("shared-recipes", {id: sharedRecipe, dateLastCopy: new Date()})
-            await database.merge("users", {id: user.id, [`recipes.${recipe.id}`]: recipe})
-
-            logger.info("Recipes.copySharedRecipe", logHelper.user(user), logHelper.recipe(recipe))
-            return recipe
-        } catch (ex) {
-            logger.error("Recipes.copySharedRecipe", logHelper.user(user), ex)
             throw ex
         }
     }

--- a/src/wahoo/activities.ts
+++ b/src/wahoo/activities.ts
@@ -132,6 +132,12 @@ export class WahooActivities {
                 throw new Error("Missing activity file URL in the webhook data")
             }
 
+            // Only download FIT files from Wahoo domains.
+            const fileHost = new URL(webhookData.workout_summary.file.url).hostname.toLowerCase()
+            if (fileHost != "wahooligan.com" && !fileHost.endsWith(".wahooligan.com")) {
+                throw new Error("Invalid activity file URL")
+            }
+
             // Files are served by the CDN and need no authentication, so tokens are
             // not validated here (refreshing without an actual API call would leave
             // unrevoked access tokens behind).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements the follow-up hardening from the core security audit. Scope is limited to the items that were explicitly requested.

### Changes
- **Shared recipes:** delete unused `copySharedRecipe()`. When updating an existing shared recipe (`id` starts with `s`), require that the stored `userId` matches the owner.
- **Garmin FIT downloads:** reject `callbackURL` hosts that are not `garmin.com` or a subdomain of it.
- **Wahoo FIT downloads:** reject file URLs whose host is not `wahooligan.com` or a subdomain of it.
- **GearWear:** `toggleGearComponents()` now refuses configs whose `userId` does not match the activity owner.
- **Token logs:** EventManager token events now log only `*` plus the last two characters (`slice(-2)`), instead of leaking the full value via `substring(-2)`.
- **GDPR export:** strip `garminAuthState`, `wahooAuthState`, and `spotifyAuthState` (in addition to existing token fields).
- **Dependencies:** remove unused `paypal-rest-sdk`.

### Intentionally unchanged
PayPal/GitHub webhook signature checks, default cookie secret, and crypto IV handling, as requested.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71143dac-b2ad-432f-9af3-4765f1169f66?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71143dac-b2ad-432f-9af3-4765f1169f66&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

