### PR TITLE
Add MCP server settings

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -60,6 +60,23 @@
         // Only accept connections coming via Cloudflare by default.
         "requireCloudflare": true
     },
+    // Remote MCP server (PRO only). Hosted by the web app at /mcp.
+    "mcp": {
+        // Path of the MCP Streamable HTTP endpoint.
+        "path": "/mcp",
+        // OAuth scope advertised to MCP clients.
+        "scope": "mcp",
+        // Access token lifetime in hours.
+        "accessTokenHours": 1,
+        // Refresh token lifetime in days.
+        "refreshTokenDays": 30,
+        // Authorization code lifetime in minutes.
+        "authCodeMinutes": 10,
+        // Pending authorization request lifetime in minutes (covers the Strava login round-trip).
+        "authRequestMinutes": 15,
+        // Dynamically registered OAuth clients expire after this many days of issuance.
+        "clientDays": 365
+    },
     // Afiliate settings (also used for the Country Linkify module).
     "affiliates": {
         "app": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds default `mcp` settings used by the web app's remote MCP server: path, OAuth scope, and token / client lifetimes.

The web PR at strautomator/web implements the server itself. These values are optional there (the MCP module has the same fallbacks), but documenting them here keeps production config in one place.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5773b352-0fa5-43ae-b360-4eef19071fde?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5773b352-0fa5-43ae-b360-4eef19071fde&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

