### PR TITLE
Add database.runTransaction for atomic Firestore reads and writes

### DIFF
--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -1,7 +1,7 @@
 // Strautomator Core: Database
 
-import {DocumentReference, FieldValue, Firestore, OrderByDirection} from "@google-cloud/firestore"
-import {DatabaseOptions} from "./types"
+import {DocumentReference, FieldValue, Firestore, OrderByDirection, Transaction} from "@google-cloud/firestore"
+import {DatabaseOptions, DatabaseTransaction as DatabaseTransactionApi} from "./types"
 import {cryptoProcess} from "./crypto"
 import _ from "lodash"
 import cache from "bitecache"
@@ -10,6 +10,45 @@ import logger from "anyhow"
 import dayjs from "../dayjs"
 const settings = require("setmeup").settings
 const deadlineTimeout = 1500
+
+/**
+ * Firestore transaction helpers that honour collection suffixes, decryption and date transforms.
+ */
+export class DatabaseTransaction implements DatabaseTransactionApi {
+    private db: Database
+    private txn: Transaction
+
+    constructor(db: Database, txn: Transaction) {
+        this.db = db
+        this.txn = txn
+    }
+
+    /**
+     * Read a document inside the transaction.
+     */
+    get = async (collection: string, id: string): Promise<any> => {
+        const snap = await this.txn.get(this.db.doc(collection, id))
+        if (!snap.exists) {
+            return null
+        }
+
+        const result: any = snap.data()
+        cryptoProcess(result, false)
+        this.db.transformData(result)
+        result.id = snap.id
+        return result
+    }
+
+    /**
+     * Delete a document inside the transaction.
+     */
+    delete = (collection: string, id: string): void => {
+        this.txn.delete(this.db.doc(collection, id))
+        if (this.db.cacheInMemory) {
+            cache.del(`database${this.db.collectionSuffix}`, `${collection}-${id}`)
+        }
+    }
+}
 
 /**
  * Database wrapper.
@@ -483,6 +522,25 @@ export class Database {
 
             logger.info("Database.appState.increment", id, field, value)
         }
+    }
+
+    // TRANSACTIONS
+    // --------------------------------------------------------------------------
+
+    /**
+     * Run a Firestore transaction. Use the returned {@link DatabaseTransaction} helpers so
+     * collection suffixes, field decryption and date transforms match regular get/delete calls.
+     * @param handler Callback that performs reads and writes atomically.
+     */
+    runTransaction = async <T>(handler: (transaction: DatabaseTransaction) => Promise<T>): Promise<T> => {
+        if (settings.database.writeDisabled) {
+            logger.warn("Database.runTransaction", "WRITE DISABLED")
+            throw new Error("Database writes are disabled")
+        }
+
+        return this.firestore.runTransaction(async (txn) => {
+            return handler(new DatabaseTransaction(this, txn))
+        })
     }
 
     // HELPERS

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -15,6 +15,16 @@ export interface DatabaseOptions {
 }
 
 /**
+ * Helpers passed to {@link Database.runTransaction} for atomic reads and writes.
+ */
+export interface DatabaseTransaction {
+    /** Read a document inside the transaction. */
+    get: (collection: string, id: string) => Promise<any>
+    /** Delete a document inside the transaction. */
+    delete: (collection: string, id: string) => void
+}
+
+/**
  * Generic database search query options.
  */
 export interface DatabaseSearchOptions {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `database.runTransaction()` to the core Database wrapper so callers can perform atomic read/delete (or read/write) operations without races between concurrent requests.

## Changes

- New `DatabaseTransaction` helper with `get()` and `delete()` that honour collection suffixes, field decryption, date transforms, and in-memory cache invalidation — matching regular `database.get()` / `database.delete()` behaviour.
- New `database.runTransaction(handler)` method that runs the handler inside `firestore.runTransaction()`.

## Motivation

The MCP OAuth store needs to consume single-use authorization codes and refresh tokens atomically. Without transactions, concurrent token requests can both read a grant before either deletes it and issue multiple token pairs from one grant.

Used by: strautomator/web PR #47 (MCP OAuth fixes).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5773b352-0fa5-43ae-b360-4eef19071fde?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5773b352-0fa5-43ae-b360-4eef19071fde&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

