### PR TITLE
Remove deprecated in-memory Firestore database caching

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -173,8 +173,6 @@
         // If you're hosting multiple sites or services within the same Google Project,
         // you might add a default suffix to Firestore collection names.
         "collectionSuffix": "",
-        // Cache duration to keep database documents in memory for different colletions. Value set in seconds.
-        "cacheDuration": null,
         // Encryption options.
         "crypto": {
             "algorithm": "aes-256-cbc",

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -4,7 +4,6 @@ import {DocumentReference, FieldValue, Firestore, OrderByDirection, Transaction}
 import {DatabaseOptions, DatabaseTransaction as DatabaseTransactionApi} from "./types"
 import {cryptoProcess} from "./crypto"
 import _ from "lodash"
-import cache from "bitecache"
 import jaul from "jaul"
 import logger from "anyhow"
 import dayjs from "../dayjs"
@@ -44,9 +43,6 @@ export class DatabaseTransaction implements DatabaseTransactionApi {
      */
     delete = (collection: string, id: string): void => {
         this.txn.delete(this.db.doc(collection, id))
-        if (this.db.cacheInMemory) {
-            cache.del(`database${this.db.collectionSuffix}`, `${collection}-${id}`)
-        }
     }
 }
 
@@ -62,11 +58,6 @@ export class Database {
     static newInstance() {
         return new this()
     }
-
-    /**
-     * Enable the in-memory cache of DB results?
-     */
-    cacheInMemory: boolean = false
 
     /**
      * Database collection suffix.
@@ -93,12 +84,6 @@ export class Database {
             // Crypto key is global and required.
             if (!settings.database.crypto.key) {
                 throw new Error("Missing the mandatory database.crypto.key setting")
-            }
-
-            // Setup cache only if a duration was set.
-            if (dbOptions.cacheDuration) {
-                cache.setup(`database${this.collectionSuffix}`, dbOptions.cacheDuration)
-                this.cacheInMemory = true
             }
 
             const options: FirebaseFirestore.Settings = {
@@ -160,21 +145,12 @@ export class Database {
         const encryptedData = _.cloneDeep(data)
         cryptoProcess(encryptedData, true)
 
-        // Set the document, save to cache and return it.
         try {
             const result = await doc.set(encryptedData)
-            if (this.cacheInMemory) {
-                cache.set(`database${this.collectionSuffix}`, `${collection}-${id}`, data)
-            }
-
             return result.writeTime.seconds
         } catch (ex) {
             if (this.isRetryable(ex)) {
                 const result = await doc.set(encryptedData)
-                if (this.cacheInMemory) {
-                    cache.set(`database${this.collectionSuffix}`, `${collection}-${id}`, data)
-                }
-
                 return result.writeTime.seconds
             } else {
                 throw ex
@@ -203,21 +179,12 @@ export class Database {
             doc = table.doc(data.id)
         }
 
-        // Merge the data, save to cache and return it.
         try {
             const result = await doc.set(encryptedData, {merge: true})
-            if (this.cacheInMemory) {
-                cache.merge(`database${this.collectionSuffix}`, `${collection}-${doc.id}`, data)
-            }
-
             return result.writeTime.seconds
         } catch (ex) {
             if (this.isRetryable(ex)) {
                 const result = await doc.set(encryptedData, {merge: true})
-                if (this.cacheInMemory) {
-                    cache.merge(`database${this.collectionSuffix}`, `${collection}-${doc.id}`, data)
-                }
-
                 return result.writeTime.seconds
             } else {
                 throw ex
@@ -229,20 +196,10 @@ export class Database {
      * Get a single document from the specified database collection.
      * @param collection Name of the collection.
      * @param id ID of the desired document.
-     * @param skipCache If set to true, will not lookup on in-memory cache.
      */
-    get = async (collection: string, id: string, skipCache?: boolean): Promise<any> => {
+    get = async (collection: string, id: string): Promise<any> => {
         let colname = `${collection}${this.collectionSuffix}`
 
-        // First check if document is cached.
-        if (!skipCache && this.cacheInMemory) {
-            const fromCache = cache.get(`database${this.collectionSuffix}`, `${collection}-${id}`)
-            if (fromCache) {
-                return fromCache
-            }
-        }
-
-        // Continue here with a regular database fetch.
         const table = this.firestore.collection(colname)
         const doc = await table.doc(id).get()
 
@@ -253,11 +210,6 @@ export class Database {
             cryptoProcess(result, false)
             this.transformData(result)
             result.id = doc.id
-
-            // Add result to cache, only if enabled.
-            if (this.cacheInMemory) {
-                cache.set(`database${this.collectionSuffix}`, `${collection}-${id}`, result)
-            }
 
             return result
         }
@@ -403,9 +355,6 @@ export class Database {
         if (_.isString(queryOrId)) {
             const id = queryOrId as string
             await this.firestore.collection(colname).doc(id).delete()
-            if (this.cacheInMemory) {
-                cache.del(`database${this.collectionSuffix}`, `${collection}-${id}`)
-            }
 
             logger.info("Database.delete", collection, `ID ${id}`, `Deleted`)
             return 1

--- a/src/database/types.ts
+++ b/src/database/types.ts
@@ -6,8 +6,6 @@
 export interface DatabaseOptions {
     /** Database instance / connection description. */
     description?: string
-    /** Cache duration in seconds. */
-    cacheDuration?: number
     /** Collection suffix. */
     collectionSuffix?: string
     /** Ignore undefined properties? */

--- a/src/gdpr/index.ts
+++ b/src/gdpr/index.ts
@@ -94,12 +94,12 @@ export class GDPR {
             jsonData["Activities"] = await database.search("activities", where)
             jsonData["FitActivities"] = {Garmin: await database.search("garmin", where), Wahoo: await database.search("wahoo", where)}
             jsonData["Automations"] = {Stats: await database.search("recipe-stats", where), Shared: await database.search("shared-recipes", where)}
-            jsonData["AthleteRecords"] = await database.get("athlete-records", user.id, true)
+            jsonData["AthleteRecords"] = await database.get("athlete-records", user.id)
             jsonData["Calendars"] = await database.search("calendars", where)
             jsonData["GearWear"] = {Config: await database.search("gearwear", where), BatteryTracker: await database.get("gearwear-battery", user.id)}
             jsonData["Notifications"] = await database.search("notifications", where)
             jsonData["Subscription"] = await database.search("subscriptions", where)
-            jsonData["User"] = await database.get("users", user.id, true)
+            jsonData["User"] = await database.get("users", user.id)
 
             // Remove sensitive data.
             delete jsonData.User.stravaTokens


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the deprecated in-memory caching layer for Firestore collections from the `Database` wrapper.

## Changes

- Removed `bitecache` usage from `src/database/index.ts` (get/set/merge/delete and transaction delete no longer maintain an in-memory cache)
- Removed `cacheInMemory` property and `skipCache` parameter from `database.get()`
- Removed `cacheDuration` from `DatabaseOptions` and `settings.json` (`database.cacheDuration`)
- Updated GDPR export calls that passed `skipCache: true` to use the simplified `get()` signature

## Notes

Module-level in-memory caching via `bitecache` (weather, Strava, maps, etc.) and Firestore-persisted cache collections (e.g. `strava-cache`, `komoot`, `maps`) are unchanged — only the deprecated Database wrapper cache was removed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b819e27-55ca-4c82-85eb-ef305d52b8e4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b819e27-55ca-4c82-85eb-ef305d52b8e4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

